### PR TITLE
make: add script to install software

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,53 +20,11 @@ make link --config --system
 ```
 
 ## My software
+- install everything
 ```nushell
-yes | sudo apt install ...[
-    tmux,
-    tldr,
-    ripgrep,
-    fd-find,
-    sd,
-    lm-sensors,
-    ttyplot,
-]
+make install applications.nuon
 ```
+- select what to install
 ```nushell
-make gh download-asset-from-release jesseduffield/horcrux v0.2 --no-gh --asset horcrux_0.2_Linux_armv6 --extract "/tmp/horcrux-0.2-armv6"
-cp --verbose ("/tmp/horcrux-0.2-armv6/horcrux" | path expand) ("~/opt/bin/horcrux" | path expand)
-```
-```nushell
-make gh download-asset-from-release cli/cli v2.74.2 --no-gh --asset gh_2.74.2_linux_armv6
-mkdir ("~/.local/share/man/man1" | path expand)
-cp --verbose ("/tmp/gh_2.74.2_linux_armv6/bin/gh" | path expand) ("~/opt/bin/gh" | path expand)
-cp --verbose ("/tmp/gh_2.74.2_linux_armv6/share/man/man1/*" | into glob) ("~/.local/share/man/man1" | path expand)
-```
-
-```nushell
-use git *
-cd (git clone https://github.com/antoineeestevaaan/find-git-repos)
-yes | sudo apt install libssl-dev
-cc -o nob nob.c -lssl -lcrypto
-git checkout bbb78cc
-./nob
-cp  build/find-git-repos-f74da46dd63b5118ab8cf499124a92902bfecc1b18609f9d6e32e395d8a44e10 ~/opt/bin/
-```
-
-```nushell
-use git *
-use misc "make"
-
-const OPT_DIR = $nu.home-path | path join opt
-
-cd (git clone https://github.com/neovim/neovim)
-git checkout nightly
-
-yes | sudo apt install cmake
-
-let nvim_install_dir = $OPT_DIR | path join $"nvim-(git rev-parse HEAD)"
-
-make -V { CMAKE_BUILD_TYPE: Release }
-make -V { CMAKE_INSTALL_PREFIX: $nvim_install_dir} install
-
-ln --force --symbolic ($nvim_install_dir | path join bin nvim) ($OPT_DIR | path join bin nvim)
+open applications.nuon | where name == neovim | make install --from-stdin
 ```

--- a/applications.nuon
+++ b/applications.nuon
@@ -1,14 +1,15 @@
 [
-    { kind: "system" , package: { apt: "tmux"       } },
-    { kind: "system" , package: { apt: "ripgrep"    } },
-    { kind: "system" , package: { apt: "fd-find"    } },
-    { kind: "system" , package: { apt: "sd"         } },
-    { kind: "system" , package: { apt: "lm-sensors" } },
-    { kind: "system" , package: { apt: "ttyplot"    } },
+    { name: "tmux"       , kind: "system" , package: { apt: "tmux"       } },
+    { name: "ripgrep"    , kind: "system" , package: { apt: "ripgrep"    } },
+    { name: "fd-find"    , kind: "system" , package: { apt: "fd-find"    } },
+    { name: "sd"         , kind: "system" , package: { apt: "sd"         } },
+    { name: "lm-sensors" , kind: "system" , package: { apt: "lm-sensors" } },
+    { name: "ttyplot"    , kind: "system" , package: { apt: "ttyplot"    } },
     {
+        name: "horcrux",
         kind: "release",
         host: "github.com",
-        name: "jesseduffield/horcrux",
+        repo: "jesseduffield/horcrux",
         tag: "v0.2",
         asset: "horcrux_0.2_Linux_armv6",
         inner: false,
@@ -20,9 +21,10 @@
         ],
     },
     {
+        name: "gh",
         kind: "release",
         host: "github.com",
-        name: "cli/cli",
+        repo: "cli/cli",
         tag: "v2.74.2",
         asset: "gh_2.74.2_linux_armv6",
         inner: true,
@@ -38,6 +40,7 @@
         ]
     },
     {
+        name: "find-git-repos",
         kind: "build",
         git: "https://github.com/antoineeestevaaan/find-git-repos",
         deps: [
@@ -56,6 +59,7 @@
         ],
     },
     {
+        name: "neovim",
         kind: "build",
         git: "https://github.com/neovim/neovim",
         deps: [

--- a/applications.nuon
+++ b/applications.nuon
@@ -15,7 +15,7 @@
         install: [
             {
                 kind: "bin",
-                path: "horcrux",
+                path: "$var::ROOT/horcrux",
             },
         ],
     },
@@ -29,11 +29,11 @@
         install: [
             {
                 kind: "bin",
-                path: "bin/gh",
+                path: "$var::ROOT/bin/gh",
             },
             {
                 kind: "man",
-                pages: [ "share/man/man1/*" ],
+                pages: [ "$var::ROOT/share/man/man1/*" ],
             },
         ]
     },
@@ -51,7 +51,7 @@
         install: [
             {
                 kind: "bin",
-                path: "build/find-git-repos-f74da46dd63b5118ab8cf499124a92902bfecc1b18609f9d6e32e395d8a44e10",
+                path: "$var::ROOT/build/find-git-repos-f74da46dd63b5118ab8cf499124a92902bfecc1b18609f9d6e32e395d8a44e10",
             },
         ],
     },
@@ -63,7 +63,7 @@
         ],
         checkout: "nightly",
         variables: {
-            nvim_install_dir: '$var::_OPT_DIR | path join $"nvim-(git rev-parse HEAD)"'
+            nvim_install_dir: '$var::OPT_DIR | path join $"nvim-(git rev-parse HEAD)"'
         },
         build: [
             'make -V { CMAKE_BUILD_TYPE: Release }',

--- a/applications.nuon
+++ b/applications.nuon
@@ -1,10 +1,10 @@
 [
-    { kind: "apt" , package: "tmux"       },
-    { kind: "apt" , package: "ripgrep"    },
-    { kind: "apt" , package: "fd-find"    },
-    { kind: "apt" , package: "sd"         },
-    { kind: "apt" , package: "lm-sensors" },
-    { kind: "apt" , package: "ttyplot"    },
+    { kind: "system" , package: { apt: "tmux"       } },
+    { kind: "system" , package: { apt: "ripgrep"    } },
+    { kind: "system" , package: { apt: "fd-find"    } },
+    { kind: "system" , package: { apt: "sd"         } },
+    { kind: "system" , package: { apt: "lm-sensors" } },
+    { kind: "system" , package: { apt: "ttyplot"    } },
     {
         kind: "release",
         host: "github.com",
@@ -41,7 +41,7 @@
         kind: "build",
         git: "https://github.com/antoineeestevaaan/find-git-repos",
         deps: [
-            { kind: "apt" , package: "libssl-dev" },
+            { kind: "system" , package: { apt: "libssl-dev" } },
         ],
         checkout: "bbb78cc",
         build: [
@@ -59,7 +59,7 @@
         kind: "build",
         git: "https://github.com/neovim/neovim",
         deps: [
-            { kind: "apt" , package: "cmake" },
+            { kind: "system" , package: { apt: "cmake" } },
         ],
         checkout: "nightly",
         variables: {

--- a/applications.nuon
+++ b/applications.nuon
@@ -1,0 +1,79 @@
+[
+    { kind: "apt" , package: "tmux"       },
+    { kind: "apt" , package: "ripgrep"    },
+    { kind: "apt" , package: "fd-find"    },
+    { kind: "apt" , package: "sd"         },
+    { kind: "apt" , package: "lm-sensors" },
+    { kind: "apt" , package: "ttyplot"    },
+    {
+        kind: "release",
+        host: "github.com",
+        name: "jesseduffield/horcrux",
+        tag: "v0.2",
+        asset: "horcrux_0.2_Linux_armv6",
+        inner: false,
+        install: [
+            {
+                kind: "bin",
+                path: "horcrux",
+            },
+        ],
+    },
+    {
+        kind: "release",
+        host: "github.com",
+        name: "cli/cli",
+        tag: "v2.74.2",
+        asset: "gh_2.74.2_linux_armv6",
+        inner: true,
+        install: [
+            {
+                kind: "bin",
+                path: "bin/gh",
+            },
+            {
+                kind: "man",
+                pages: [ "share/man/man1/*" ],
+            },
+        ]
+    },
+    {
+        kind: "build",
+        git: "https://github.com/antoineeestevaaan/find-git-repos",
+        deps: [
+            { kind: "apt" , package: "libssl-dev" },
+        ],
+        checkout: "bbb78cc",
+        build: [
+            "cc -o nob nob.c -lssl -lcrypto",
+            "./nob",
+        ],
+        install: [
+            {
+                kind: "bin",
+                path: "build/find-git-repos-f74da46dd63b5118ab8cf499124a92902bfecc1b18609f9d6e32e395d8a44e10",
+            },
+        ],
+    },
+    {
+        kind: "build",
+        git: "https://github.com/neovim/neovim",
+        deps: [
+            { kind: "apt" , package: "cmake" },
+        ],
+        checkout: "nightly",
+        variables: {
+            nvim_install_dir: '$var::_OPT_DIR | path join $"nvim-(git rev-parse HEAD)"'
+        },
+        build: [
+            'make -V { CMAKE_BUILD_TYPE: Release }',
+            'make -V { CMAKE_INSTALL_PREFIX: $var::nvim_install_dir } install',
+        ],
+        install: [
+            {
+                kind: "link",
+                path: "$var::nvim_install_dir | path join bin nvim",
+            },
+        ],
+    },
+]

--- a/log.nu
+++ b/log.nu
@@ -1,0 +1,31 @@
+export def "str color" [color: string]: [ string -> string ] {
+    $"(ansi $color)($in)(ansi reset)"
+}
+
+def level-to-int []: [ string -> int ] {
+    match ($in | str trim) {
+        "FATAL"                =>  0,
+        "ERROR"                => 10,
+        "WARNING"              => 20,
+        "INFO" | "OK" | "HINT" => 30,
+        "HINT" | "DEBUG"       => 40,
+        "TRACE"                => 50,
+        _                      => 30,
+    }
+}
+
+def log [level: string, color: string, msg: string] {
+    let min_level = $env.LOG_LEVEL? | default "INFO"
+    if ($level | level-to-int) <= ($min_level | level-to-int) {
+        print $"[($level | str color $color)] ($msg)"
+    }
+}
+
+export def "log fatal"   [msg: string] { log "FATAL"   "red_bold"       $msg }
+export def "log error"   [msg: string] { log "ERROR"   "red"            $msg }
+export def "log warning" [msg: string] { log "WARNING" "yellow"         $msg }
+export def "log info"    [msg: string] { log "INFO"    "cyan"           $msg }
+export def "log debug"   [msg: string] { log "DEBUG"   "default_dimmed" $msg }
+export def "log ok"      [msg: string] { log "OK"      "green"          $msg }
+export def "log hint"    [msg: string] { log "HINT"    "purple"         $msg }
+export def "log trace"   [msg: string] { log "TRACE"   "black_dimmed"   $msg }

--- a/make.nu
+++ b/make.nu
@@ -364,10 +364,13 @@ export def "install" [file?: path, --from-stdin]: [ any -> nothing ] {
                 let entry = $entry | update item { default {} variables | default [] deps }
 
                 [
-                    $"use (pwd | path join .config nushell modules git) *"
                     $"use (pwd | path join .config nushell modules misc) \"make\""
                     $"use (pwd | path join make.nu)"
-                    $"cd \(git clone ($entry.item.git)\)"
+                    $"let cache = \"($nu.home-path | path join .cache antoineeestevaaan doffiles ($entry.item.git | url parse | $in.host + $in.path))\""
+                    "if not ($cache | path exists) {"
+                    $"    git clone ($entry.item.git) $cache"
+                    "}"
+                    "cd $cache"
                     ...($entry.item.deps | enumerate | each { |dep|
                         let cp = $cp | split cell-path | append [ "deps" $dep.index ] | into cell-path
 

--- a/make.nu
+++ b/make.nu
@@ -320,6 +320,10 @@ def __install [root: string, --cp: cell-path]: [ list -> list<string>, table -> 
     } | flatten
 }
 
+
+@example "install everything"                       { make install applications.nuon }
+@example "install without interactive confirmation" { make install --no-confirm applications.nuon }
+@example "select what to install, e.g. Neovim"      { open applications.nuon | where name == neovim | make install --from-stdin }
 export def "install" [
     file?: path,
     --from-stdin,

--- a/make.nu
+++ b/make.nu
@@ -300,7 +300,11 @@ def __install [root: string, --cp: cell-path]: [ list -> list<string>, table -> 
     } | flatten
 }
 
-export def "install" [file?: path, --from-stdin]: [ any -> nothing ] {
+export def "install" [
+    file?: path,
+    --from-stdin,
+    --no-confirm (-y),
+]: [ any -> nothing ] {
     let install_scripts = if $from_stdin {
         $in
     } else {
@@ -406,9 +410,8 @@ export def "install" [file?: path, --from-stdin]: [ any -> nothing ] {
     for is in $install_scripts {
         print ($is | nu-highlight)
 
-        let res = [ no, yes ] | input list "Install ?"
-        if $res != "yes" {
-            continue
+        if not $no_confirm {
+            if ([ no, yes ] | input list "Install ?") != "yes" { continue }
         }
 
         let file = mktemp --tmpdir dotfiles.XXXXXXX

--- a/make.nu
+++ b/make.nu
@@ -346,11 +346,11 @@ export def "install" [
             "system" => { $entry.item | __system --cp $cp },
             "release" => {
                 if not ($entry.item | check-field host    --types [string]      --cp $cp) { return }
-                if not ($entry.item | check-field name    --types [string]      --cp $cp) { return }
+                if not ($entry.item | check-field repo    --types [string]      --cp $cp) { return }
                 if not ($entry.item | check-field tag     --types [string]      --cp $cp) { return }
                 if not ($entry.item | check-field asset   --types [string]      --cp $cp) { return }
                 if not ($entry.item | check-field install --types [list, table] --cp $cp) { return }
-                $entry.item | check-extra-fields [ kind, host, name, tag, asset, install, inner ] --cp $cp
+                $entry.item | check-extra-fields [ kind, host, repo, tag, asset, install, inner ] --cp $cp
 
                 let entry = $entry | update item { default true inner }
 
@@ -361,7 +361,7 @@ export def "install" [
                         } else {
                             $"$nu.temp-path | path join ($entry.item.asset)"
                         }
-                        cmd log $"make gh download-asset-from-release ($entry.item.name) ($entry.item.tag) --no-gh --asset ($entry.item.asset) --extract \(($extract)\)"
+                        cmd log $"make gh download-asset-from-release ($entry.item.repo) ($entry.item.tag) --no-gh --asset ($entry.item.asset) --extract \(($extract)\)"
                     },
                     _ => { log error $"unknown host ($entry.item.host) at ($cp)"; return },
                 }

--- a/make.nu
+++ b/make.nu
@@ -400,5 +400,17 @@ export def "install" [file?: path, --from-stdin]: [ any -> nothing ] {
         $lines | str join "\n"
     }
 
-    print ($install_scripts | table -e)
+    for is in $install_scripts {
+        print ($is | nu-highlight)
+
+        let res = [ no, yes ] | input list "Install ?"
+        if $res != "yes" {
+            continue
+        }
+
+        let file = mktemp --tmpdir dotfiles.XXXXXXX
+        $is | save --force $file
+
+        ^$nu.current-exe -I (pwd | path join .config nushell modules) $file
+    }
 }

--- a/make.nu
+++ b/make.nu
@@ -24,6 +24,7 @@ const NOT_CONFIG_FILE_PATTERN = [
     $SYSTEM_FILE_PATTERN,
     make.nu,
     bootstrap.sh,
+    applications.nuon,
 ]
 
 export def link [--config, --system, --dry-run] {

--- a/make.nu
+++ b/make.nu
@@ -14,17 +14,6 @@ def find-files [
         }
 }
 
-def __log [
-    level: string,
-    color: string,
-    msg: string,
-] {
-    print $"[(ansi $color)($level)(ansi reset)] ($msg)"
-}
-def "log debug"   [msg: string] { __log DBG default_dimmed $msg }
-def "log info"    [msg: string] { __log INF cyan           $msg }
-def "log warning" [msg: string] { __log WRN yellow         $msg }
-
 const SYSTEM_FILE_PATTERN = "@*/**"
 const NOT_CONFIG_FILE_PATTERN = [
     .git/**/*,

--- a/make.nu
+++ b/make.nu
@@ -228,7 +228,7 @@ def expand-vars [--root: string]: [ string -> string ] {
 }
 
 def "cmd log" [cmd: string, --indent: int = 4, --indent-level: int = 0]: [ nothing -> list<string> ] {
-    let indentation = " " | repeat (($indent_level + 1) * $indent) | str join ""
+    let indentation = " " | repeat ($indent_level * $indent) | str join ""
     [
         $"($indentation)log info \"($cmd | str trim | nu-highlight)\""
         $cmd
@@ -389,7 +389,7 @@ export def "install" [
 
                 [
                     $"if not \(\"($cache)\" | path exists\) {"
-                    ...(cmd log $"    git clone ($entry.item.git) ($cache)")
+                    ...(cmd log $"    git clone ($entry.item.git) ($cache)" --indent-level 1)
                     "}"
                     ...(cmd log $"cd ($cache)")
                     ...($entry.item.deps | enumerate | each { |dep|

--- a/make.nu
+++ b/make.nu
@@ -429,16 +429,17 @@ export def "install" [
     }
 
     for is in $install_scripts {
+        let file = mktemp --tmpdir dotfiles.XXXXXXX
+        $is | save --force $file
+
         print ("=" | repeat (term size).columns | str join "")
+        print $"(ansi default_dimmed)# complete script: ($file)(ansi reset)"
         print ($is | lines | where $it !~ '^\s*log info |^\s*use ' | str join "\n" | nu-highlight)
         print ("=" | repeat (term size).columns | str join "")
 
         if not $no_confirm {
             if ([ no, yes ] | input list "Install ?") != "yes" { continue }
         }
-
-        let file = mktemp --tmpdir dotfiles.XXXXXXX
-        $is | save --force $file
 
         ^$nu.current-exe -I (pwd | path join .config nushell modules) $file
     }


### PR DESCRIPTION
this adds
- the `make install` command to `make.nu`
- the `applications.nuon` file that lists my software
- the `log.nu` module to log stuff

> [!note] Note
> for now there is no _lock file_ to keep track of what is actually installed
> on the system.

## Changelog
- **make: add install to list install scripts**
- **make: use log functions from log.nu**
- **add applications.nuon**
- **applications.nuon: fix paths**
- **make: start installing applications**
- **make: clone repos to cache in install**
- **make; add --no-confirm to install**
- **(wip) make: log commands**
- **make: finish `make install`**
- **make: refactor generated imports and __system in `install`**
- **make: fix indent in `install` logs**
- **make: show path to complete install script**
